### PR TITLE
Simple dots fix

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -27,7 +27,7 @@ num_untracked=0
 while IFS='' read -r line || [[ -n "$line" ]]; do
   status=${line:0:2}
   case "$status" in
-    \#\#) branch_line="$line" ;;
+    \#\#) branch_line="${line/\.\.\./^}" ;;
     ?M) ((num_changed++)) ;;
     U?) ((num_conflicts++)) ;;
     \?\?) ((num_untracked++)) ;;
@@ -50,13 +50,13 @@ if (( num_changed == 0 && num_staged == 0 && num_untracked == 0 && num_stashed =
   clean=1
 fi
 
-IFS="." read -ra line <<< "${branch_line/\#\# }"
-branch="${line[0]}"
+IFS="^" read -ra branch_fields <<< "${branch_line/\#\# }"
+branch="${branch_fields[0]}"
 remote=
 
 if [[ "$branch" == *"Initial commit on"* ]]; then
-  IFS=" " read -ra branch_line <<< "$branch"
-  branch="${branch_line[3]}"
+  IFS=" " read -ra fields <<< "$branch"
+  branch="${fields[3]}"
   remote="_NO_REMOTE_TRACKING_"
 elif [[ "$branch" == *"no branch"* ]]; then
   tag=$( git describe --exact-match )
@@ -66,10 +66,10 @@ elif [[ "$branch" == *"no branch"* ]]; then
     branch="_PREHASH_$( git rev-parse --short HEAD )"
   fi
 else
-  if [[ "${#line[@]}" -eq 1 ]]; then
+  if [[ "${#branch_fields[@]}" -eq 1 ]]; then
     remote="_NO_REMOTE_TRACKING_"
   else
-    IFS="[,]" read -ra remote_line <<< "${line[3]}"
+    IFS="[,]" read -ra remote_line <<< "${branch_fields[1]}"
     for rline in "${remote_line[@]}"; do
       if [[ "$rline" == *ahead* ]]; then
         num_ahead=${rline:6}

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -69,7 +69,7 @@ else
   if [[ "${#branch_fields[@]}" -eq 1 ]]; then
     remote="_NO_REMOTE_TRACKING_"
   else
-    IFS="[,]" read -ra remote_line <<< "${line[3]}"
+    IFS="[,]" read -ra remote_line <<< "${branch_fields[1]}"
     for rline in "${remote_line[@]}"; do
       if [[ "$rline" == *ahead* ]]; then
         num_ahead=${rline:6}


### PR DESCRIPTION
A simple fix where we sub `...` with `^`, since `^` isn't a valid branch character. This causes us to renumber our arrays. So adjust that `[3]` to `[1]`. Also renamed a variable to `fields`, because it's confusing to use `branch_line` both as an array and not as an array.
